### PR TITLE
Add support for returning ClientID As a custom header

### DIFF
--- a/cmd/simple-ingress-external-auth/config.go
+++ b/cmd/simple-ingress-external-auth/config.go
@@ -19,6 +19,7 @@ type CmdConfig struct {
 	MetricsPath        string
 	HealthCheckPath    string
 	PprofPath          string
+	ClientIdHeader     string
 }
 
 // NewCmdConfig returns a new command configuration.
@@ -36,6 +37,7 @@ func NewCmdConfig(args []string) (*CmdConfig, error) {
 	app.Flag("authentication-path", "The path user for authenticating then tokens.").Default("/auth").StringVar(&c.AuthenticationPath)
 	app.Flag("token-config-data", "The raw data token configuration.").StringVar(&c.TokenConfigData)
 	app.Flag("token-config-file", "The raw data token configuration file (can't be used with token-config-data).").StringVar(&c.TokenConfigFile)
+	app.Flag("client-id-header", "Return the client id as a custom header").StringVar(&c.ClientIdHeader)
 
 	// Internal.
 	app.Flag("internal-listen-address", "The address where the HTTP internal data (metrics, pprof...) server will be listening.").Default(":8081").StringVar(&c.InternalListenAddr)

--- a/cmd/simple-ingress-external-auth/simple-ingress-external-auth.go
+++ b/cmd/simple-ingress-external-auth/simple-ingress-external-auth.go
@@ -78,7 +78,7 @@ func Run(ctx context.Context, args []string, stdout, stderr io.Writer) error {
 		appSvc := appauth.NewService(logger, metricsRecorder, repo)
 
 		// Create server.
-		handler := httpauthenticate.New(logger, metricsRecorder, appSvc)
+		handler := httpauthenticate.New(logger, metricsRecorder, appSvc, cmdCfg.ClientIdHeader)
 		mux := http.NewServeMux()
 		mux.Handle(cmdCfg.AuthenticationPath, handler)
 

--- a/internal/http/authenticate/authenticate.go
+++ b/internal/http/authenticate/authenticate.go
@@ -15,7 +15,7 @@ import (
 )
 
 // New returns an HTTP handler that knows how to authenticate external requests.
-func New(logger log.Logger, metricRec metrics.Recorder, authAppSvc auth.Service) http.Handler {
+func New(logger log.Logger, metricRec metrics.Recorder, authAppSvc auth.Service, clientIdHeader string) http.Handler {
 	authHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		// Map request to model.
 		review, err := mapRequestToModel(r)
@@ -49,6 +49,10 @@ func New(logger log.Logger, metricRec metrics.Recorder, authAppSvc auth.Service)
 			return
 		}
 
+		// If enabled add the ClientId as a response header if the token has a client ID defined
+		if clientIdHeader != "" && resp.ClientID != "" {
+			w.Header().Set(clientIdHeader, resp.ClientID)
+		}
 		w.WriteHeader(http.StatusOK)
 	})
 


### PR DESCRIPTION
This is useful for services like Loki / Cortex / Mimir where an header is used to define to which tenant the request belongs to

https://grafana.com/docs/loki/latest/operations/multi-tenancy/

In the case of Loki by starting the auth service with a flag like `--client-id-header X-Scope-OrgId` will return this header in the response with the client the token belongs to 

this is in turn set by Nginx ( in my case ) in the request sent to Loki backend 

Test setup using this feature can be found : https://github.com/primeroz/nginx-external-auth-kind

```
                  ┌──────────────┐
                  │              │
                  │   promtail   │
                  │              │
                  └───────┬──────┘
                          │
                          │Host: Loki
                          │Bearer Token 12345
                          │
                    ┌─────▼────┐
                    │          │
                    │          │
                    │  NGINX   │
                    │          │
                    └┬──▲─┬────┘
                     │  │ │
                     │  │ │
                     │  │ │1
                     │  │ │           ┌──────────────────┐
                     │  │ └───────────►                  │
                     │  │2            │ external-auth    │
                     │  └─────────────┤                  │
                     │                │ 12345 : client1  │
                     │                │ 45678 : client2  │
                     │3               └──────────────────┘
                     │
                     │X-Scope-Orgid: client1|client2
                ┌────▼─────────────┐
                │                  │
                │  Loki            │
                │                  │
                │                  │
                │                  │
                │                  │
                └──────────────────┘
```
